### PR TITLE
fix: error on naming not found file

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -16,7 +16,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
     messages: {
       ...(await import(`../../messages/${locale}/home.json`)).default,
       ...(await import(`../../messages/${locale}/auth.json`)).default,
-      ...(await import(`../../messages/${locale}/notFound.json`)).default,
+      ...(await import(`../../messages/${locale}/not-found.json`)).default,
     },
   };
 });


### PR DESCRIPTION
This pull request includes a small change to the `src/i18n/request.ts` file. The change corrects the file path for the `notFound.json` import to use a hyphen instead of camel case.

* [`src/i18n/request.ts`](diffhunk://#diff-9e16e573762332d08dd81f11bf42e6f005c91cbdef8ac89d806f9dffa003983fL19-R19): Updated the import path for the `notFound.json` file to `not-found.json`.